### PR TITLE
fix: only initialize variable `g:searchlist_maps` if it hasn't by user already

### DIFF
--- a/plugin/searchlist.vim
+++ b/plugin/searchlist.vim
@@ -42,7 +42,9 @@ endfunction
 " Users can change this if they want to set their own maps or if they already
 " have maps for the common search commands and want to tie them in with
 " vim-searchlist.
-let g:searchlist_maps = "all"
+if !exists("g:searchlist_maps")
+    let g:searchlist_maps = "all"
+endif
 
 if g:searchlist_maps ==? "all"
     call s:CreateAllMaps()


### PR DESCRIPTION
Currently `let g:searchlist_maps = "all"` runs without any condition. This means that even if the user has used `"search_only"` as their preference, we are overriding it with `all`. With this PR, we only initialize the variable if it hasn't yet already.